### PR TITLE
 Temporarily skip tests that require r-gt given issues with r-gt from r-v8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -78,6 +78,8 @@ test:
     - r-codetools
     # FIXME: see temporary patch above for r-gt issues from r-v8
     # - r-gt
+    - libgdal-pg
+    - libgdal-postgisraster
   commands:
     - $R -e "library('gdalraster')"  # [not win]
     - $R -e "testthat::test_file('tests/testthat.R', stop_on_failure=TRUE)"  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,10 +10,15 @@ source:
     - {{ cran_mirror }}/src/contrib/gdalraster_{{ version }}.tar.gz
     - {{ cran_mirror }}/src/contrib/Archive/gdalraster/gdalraster_{{ version }}.tar.gz
   sha256: 5a52e24e10e44163dfc366007a356dfc27f9d28353d557b507e46d119f3b6ef2
+  patches:
+    # FIXME: temporarily skip tests that require r-gt
+    # these are currently failing given issues with r-gt from r-v8
+    # c.f. https://github.com/conda-forge/r-v8-feedstock/issues/47
+    - patches/temp-test-skip-for-gt-issue.patch
 
 build:
   skip: true  # [win]
-  number: 1
+  number: 2
   rpaths:
     - lib/R/lib/
     - lib/
@@ -66,18 +71,18 @@ test:
     - tests/
   requires:
     - r-testthat
-    # FIXME: Without codetools, gdalraster raises multiple warnings of form
+    # add "CRAN recommended" package codetools since conda-forge test with only r-base
+    # avoids gdalraster raising multiple warnings of form:
     # code for methods in class Rcpp_... was not checked for suspicious field assignments (recommended package ‘codetools’ not available?)
+    # cf. https://github.com/conda-forge/r-gdalraster-feedstock/pull/1#issuecomment-3138823999
     - r-codetools
-    # FIXME:
+    # FIXME: see temporary patch above for r-gt issues from r-v8
     # - r-gt
   commands:
     - $R -e "library('gdalraster')"  # [not win]
-    # FIXME: Testing is failing given issues with r-gt from r-v8
-    # c.f. https://github.com/conda-forge/r-v8-feedstock/issues/47
-    # - $R -e "testthat::test_file('tests/testthat.R', stop_on_failure=TRUE)"  # [not win]
+    - $R -e "testthat::test_file('tests/testthat.R', stop_on_failure=TRUE)"  # [not win]
     - "\"%R%\" -e \"library('gdalraster')\""  # [win]
-    # - "\"%R%\" -e \"testthat::test_file('tests/testthat.R', stop_on_failure=TRUE)\""  # [win]
+    - "\"%R%\" -e \"testthat::test_file('tests/testthat.R', stop_on_failure=TRUE)\""  # [win]
 
 about:
   home: https://github.com/USDAForestService/gdalraster

--- a/recipe/patches/temp-test-skip-for-gt-issue.patch
+++ b/recipe/patches/temp-test-skip-for-gt-issue.patch
@@ -1,0 +1,13 @@
+diff --git a/tests/testthat/test-gdal_rat.R b/tests/testthat/test-gdal_rat.R
+index 3d93109e..83733f7e 100644
+--- a/tests/testthat/test-gdal_rat.R
++++ b/tests/testthat/test-gdal_rat.R
+@@ -1,4 +1,8 @@
+ test_that("buildRAT/displayRAT work", {
++    # temporary skip for conda-forge tests given issues with r-gt from r-v8
++    # c.f. https://github.com/conda-forge/r-v8-feedstock/issues/47
++    skip_if_not_installed("gt")
++
+     evt_file <- system.file("extdata/storml_evt.tif", package="gdalraster")
+     evt_csv <- system.file("extdata/LF20_EVT_220.csv", package="gdalraster")
+     evt_tbl <- read.csv(evt_csv)


### PR DESCRIPTION
Adds patch to temporarily skip tests that require `r-gt` (fixes #2)
* these are currently failing given issues with `r-gt` from `r-v8`
* c.f. https://github.com/conda-forge/r-v8-feedstock/issues/47

Also adds `libgdal-pg` and `libgdal-postgisraster` plug-in packages for the tests only.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* NA Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.