### PR TITLE
Use libgdal meta-package instead of libgdal-core

### DIFF
--- a/.ci_support/linux_64_r_base4.3.yaml
+++ b/.ci_support/linux_64_r_base4.3.yaml
@@ -16,7 +16,7 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-libgdal_core:
+libgdal:
 - '3.11'
 pin_run_as_build:
   r-base:

--- a/.ci_support/linux_64_r_base4.4.yaml
+++ b/.ci_support/linux_64_r_base4.4.yaml
@@ -16,7 +16,7 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-libgdal_core:
+libgdal:
 - '3.11'
 pin_run_as_build:
   r-base:

--- a/.ci_support/linux_aarch64_r_base4.3.yaml
+++ b/.ci_support/linux_aarch64_r_base4.3.yaml
@@ -16,7 +16,7 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-libgdal_core:
+libgdal:
 - '3.11'
 pin_run_as_build:
   r-base:

--- a/.ci_support/linux_aarch64_r_base4.4.yaml
+++ b/.ci_support/linux_aarch64_r_base4.4.yaml
@@ -16,7 +16,7 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-libgdal_core:
+libgdal:
 - '3.11'
 pin_run_as_build:
   r-base:

--- a/.ci_support/linux_ppc64le_r_base4.3.yaml
+++ b/.ci_support/linux_ppc64le_r_base4.3.yaml
@@ -16,7 +16,7 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-libgdal_core:
+libgdal:
 - '3.11'
 pin_run_as_build:
   r-base:

--- a/.ci_support/linux_ppc64le_r_base4.4.yaml
+++ b/.ci_support/linux_ppc64le_r_base4.4.yaml
@@ -16,7 +16,7 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-libgdal_core:
+libgdal:
 - '3.11'
 pin_run_as_build:
   r-base:

--- a/.ci_support/osx_64_r_base4.3.yaml
+++ b/.ci_support/osx_64_r_base4.3.yaml
@@ -16,7 +16,7 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
-libgdal_core:
+libgdal:
 - '3.11'
 macos_machine:
 - x86_64-apple-darwin13.4.0

--- a/.ci_support/osx_64_r_base4.4.yaml
+++ b/.ci_support/osx_64_r_base4.4.yaml
@@ -16,7 +16,7 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
-libgdal_core:
+libgdal:
 - '3.11'
 macos_machine:
 - x86_64-apple-darwin13.4.0

--- a/.ci_support/osx_arm64_r_base4.3.yaml
+++ b/.ci_support/osx_arm64_r_base4.3.yaml
@@ -16,7 +16,7 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
-libgdal_core:
+libgdal:
 - '3.11'
 macos_machine:
 - arm64-apple-darwin20.0.0

--- a/.ci_support/osx_arm64_r_base4.4.yaml
+++ b/.ci_support/osx_arm64_r_base4.4.yaml
@@ -16,7 +16,7 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
-libgdal_core:
+libgdal:
 - '3.11'
 macos_machine:
 - arm64-apple-darwin20.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 1
+  number: 2
   rpaths:
     - lib/R/lib/
     - lib/
@@ -51,7 +51,7 @@ requirements:
     - r-nanoarrow
     - r-wk
     - r-xml2
-    - libgdal-core
+    - libgdal
   run:
     - r-base
     - r-rcpp >=1.0.7


### PR DESCRIPTION
Use `libgdal` instead of `libgdal-core` so we have the full set of drivers.
cf. https://quansight.com/post/introducing-lightweight-versions-of-gdal-and-pdal/

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* NA Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
